### PR TITLE
Update environment from docker

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -63,3 +63,9 @@ then update the environment.yml file so others can clone your environment with:
 ``` bash
 mamba env export --no-builds -f environment.yml
 ```
+
+or if you are inside the docker container use `micromamba`
+
+```bash
+micromamba env export --no-build > notebooks/environment.yml
+```


### PR DESCRIPTION

Blocked by https://github.com/mamba-org/mamba/issues/2008 
Until `micromamba` is not able to export environment .yml files with pip packages it will not be possible to update and pin
environments from the docker container.

In order to update a package the environment must be available locally and use a full `mamba` installation.