### PR TITLE
Removes table of contents from notebook template

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ to deal with this kind programs.
 With cookiecutter installed, run the following command to create a new project from a local copy of the template:
 
 ```bash
-$ cookiecutter path/to/cookiecutter-science
+cookiecutter path/to/cookiecutter-science
 ```
 
 or use directly the GitHub repo as a source for the template:
 
 ```bash
-$ cookiecutter https://github.com/vizzTools/cookiecutter-science
+cookiecutter https://github.com/vizzTools/cookiecutter-science
 ```
 
 ## What's in the box?
@@ -46,7 +46,7 @@ The template will create a new project with the following structure:
 ├── .pre-commit-config.yaml     # pre-commit hooks configuration.
 ├── .gitignore
 ├── .editorconfig               # how many spaces and indentation your ide has to use.
-└── .env.example                # example of .env file.
+└── .env                        # example of .env file.
 ```
 
 Simple.
@@ -81,11 +81,13 @@ To install pre-commit, there are multiple options:
 - Installing the environment provided in the template locally, since it has pre-commit installed.
 - Installing pre-commit in your system as globally available package or using [pipx](https://pypa.github.io/pipx/).
 
-⚠**Please always install the hooks** when you start a new project with:
+ when you start a new project run the following command in the root of the project:
 
 ```shell
-$ pre-commit install
+pre-commit install
 ```
+
+⚠ **Please always run this** at the start of a new project.
 
 This will autoformat the code and run the linters every time you commit changes to the repo.
 
@@ -105,13 +107,13 @@ This allows you to run the formatters and linters for notebooks from the command
 For example:
 
 ```shell
-$ nbqa black notebooks/
+nbqa black notebooks/
 ```
 
 will format all the notebooks in the `notebooks/` folder.
 
 ```shell
-$ nbqa isort notebooks/
+nbqa isort notebooks/
 ```
 
 will sort the imports in all the notebooks in the `notebooks/` folder.
@@ -119,7 +121,7 @@ will sort the imports in all the notebooks in the `notebooks/` folder.
 Finally, to lint the code in cells with `ruff`:
 
 ```shell
-$ nbqa ruff notebooks/
+nbqa ruff notebooks/
 ```
 
 #### Scripts and IDEs
@@ -129,18 +131,18 @@ Same for pycharm.
 If you don't use any of these IDEs, you can always run the formatters from the command line (inside the env):
 
 ```shell
-$ black src/
+black src/
 ```
 
 ```shell
-$ isort src/
+isort src/
 ```
 
 _Note: the notebook engine in Vscode and pycharm is a bit more fiddly to configure for formatting and linting.
-Use the black and isort extensions available in the marketplace and check for notebook support or use `nbqa` from the
+Use the `black` and `isort` extensions available in the marketplace and check for notebook support or use `nbqa` from the
 command line._
 
-## Notebook styleguide and general guidelines
+## Notebook style guide and general guidelines
 
 The template comes with a template notebook in the `notebooks/` folder called `_template.ipynb`. It has a simple
 structure as a starting point for your notebooks.
@@ -169,4 +171,3 @@ If you need some inspiration, take a look at
 the [Peter Norvig's pytudes notebooks](https://github.com/norvig/pytudes/tree/main/ipynb).
 They are a great example of how to use notebooks in a clean and tidy way. For
 example [this one](https://github.com/norvig/pytudes/blob/main/ipynb/Economics.ipynb).
-

--- a/{{ cookiecutter.repo_name }}/notebooks/_template.ipynb
+++ b/{{ cookiecutter.repo_name }}/notebooks/_template.ipynb
@@ -13,20 +13,7 @@
     "\n",
     "## Methodology\n",
     "\n",
-    "{ Describe assumptions and processing steps. }\n",
-    "\n",
-    "## Table of Contents\n",
-    "### [Setup](#setup)\n",
-    "**[Library import](#lib_import)**\n",
-    "\n",
-    "**[Local library import](#loc_lib_import)**\n",
-    "\n",
-    "**[Utils](#utils)**\n",
-    "\n",
-    "### [{ Section }](#section_1)\n",
-    "### [{ Section }](#section_2)\n",
-    "### [Conclusion](#conclusion)\n",
-    "\n"
+    "{ Describe assumptions and processing steps. }\n"
    ]
   },
   {
@@ -34,11 +21,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='setup'></a>\n",
     "## Setup\n",
-    "<a id='lib_import'></a>\n",
-    "### Library import\n",
-    "{ Import all the required Python libraries. }"
+    "\n",
+    "### Library import\n"
    ]
   },
   {
@@ -50,33 +35,19 @@
    "outputs": [],
    "source": [
     "# imports\n",
-    "from pathlib import Path  # noqa\n",
-    "\n",
-    "import numpy as np  # noqa"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='loc_lib_import'></a>\n",
-    "### Local library import\n",
-    "{ Import all the required local libraries. }"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Include local library paths\n",
+    "from pathlib import Path  # noqa: F401\n",
     "import sys\n",
+    "\n",
+    "import numpy as np  # noqa: F401\n",
+    "\n",
+    "# Include local library paths if you have ../src/utils.py\n",
     "sys.path.append(\"../src/\")\n",
     "\n",
-    "# Import local libraries\n",
-    "from utils.data import VectorData"
+    "from utils import helper_function  # noqa: E402, F401\n",
+    "\n",
+    "\n",
+    "# or run another notebook with\n",
+    "%run another_notebook_with_utils.ipynb"
    ]
   },
   {
@@ -84,7 +55,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='utils'></a>\n",
     "### Utils\n",
     "{ Make a section of util functions if need it. }"
    ]
@@ -152,11 +122,6 @@
     "\n",
     "{ Summarize findings and next steps. }\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
ToC is available in almost all platforms that can render/edit a jupyter notebook so it does not make sense to have it hardcoded in the file.

Also fuses both imports sections to a single one since `isort` will move the imports together 